### PR TITLE
Add slack messaging integration for errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ lib/
 local/
 pip-selfcheck.json
 config/config.json
+config/config-old.json
 .cache
 man/
 *.pyc

--- a/config/config.json.example
+++ b/config/config.json.example
@@ -8,5 +8,8 @@
     "path":"/some_path",
     "when":"d",
     "interval":1
+  },
+  "slack": {
+    "slack_url":"slack-url.com/webhook-url"
   }
 }


### PR DESCRIPTION
Also includes improvements of logic routes:

  - Remove a few fatal routes, including a few exections
  - Light refactor of error messaging to slack and logs
  - Refactor of `service unavailable`, so that monitor stays alive
    and continues to retry.